### PR TITLE
chore: add meeting minutes discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/meeting-minutes.yaml
+++ b/.github/DISCUSSION_TEMPLATE/meeting-minutes.yaml
@@ -1,0 +1,47 @@
+title: "2025-07-28 [COMPONENT] Workstream minutes"
+labels: ["minutes"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Meeting minutes.
+  - type: dropdown
+    id: workstreams
+    attributes:
+      label: Workstreams
+      multiple: true
+      options:
+        - Architecture
+        - CDA
+        - Core
+        - DFM
+        - Fault Library
+        - Project
+        - Testing
+        - UDS2SOVD Proxy
+    validations:
+      required: true
+  - type: textarea
+    id: participants
+    attributes:
+      label: Participants
+      placeholder: |
+        * @user1
+        * @user2
+        ...
+    validations:
+      required: true
+  - type: textarea
+    id: agenda
+    attributes:
+      label: Agenda
+      placeholder: |
+        ...
+    validations:
+      required: true
+  - type: textarea
+    id: minutes
+    attributes:
+      label: Meeting minutes
+      placeholder: |
+        ...


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
This PR introduces a meeting minutes discussion template. If a new discussion named "Meeting minutes" is created the template will be shown to the author.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [X] I have tested my changes locally
- [X] I have added or updated documentation
- [X] I have linked related issues or discussions
- [X] I have added or updated tests

## Related

## Notes for Reviewers
A new discussion named "Meeting minutes" is required.
