### PR TITLE
chore: fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors
-
-SPDX-License-Identifier: Apache-2.0
--->
-
 ---
 name: Bug Report
 about: Report a bug to help us improve OpenSOVD
@@ -11,6 +5,12 @@ title: "[Bug] <short summary>"
 labels: ['bug', 'codeowner_review']
 assignees: ''
 ---
+
+<!--
+SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
 
 ## Description
 

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,10 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors
-
-SPDX-License-Identifier: Apache-2.0
--->
-
-
 ---
 name: Improvement
 about: Suggest a design or implementation improvement
@@ -12,6 +5,12 @@ title: 'Improvement: <short summary>'
 labels: ['improvement', 'codeowner_review']
 assignees: ''
 ---
+
+<!--
+SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
 
 ## Description
 


### PR DESCRIPTION
templates for issues are not displayed because the header was in the first line resulting in GitHub not detecting template
