### PR TITLE
chore: improve README links to meeting invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ serves as the central forum for architectural discussions and key project decisi
 We invite all contributors and interested parties to join these meetings, share their insights, and help
 shape the future of OpenSOVD.
 
-Below are links to the current meeting invitations:
+Below are links to the current meeting invitations (as `.ics` files):
 
-- 📅 [Architecture Board](meetings/Eclipse_OpenSOVD_-_Architecture_Board.ics) - Mondays 11:30 to 12:30 CET
-- 📅 [Workstream CDA](meetings/Eclipse_OpenSOVD_-_Workstream_CDA.ics) - Mondays 14:00 to 15:00 CET
-- 📅 [Workstream Gateway, Client & Server](meetings/Eclipse_OpenSOVD_-_Workstream_Core.ics) - Tuesdays 11:30 to 12:15 CET
-- 📅 [Workstream UDS2SOVD](meetings/Eclipse_OpenSOVD_-_Workstream_UDS2SOVD.ics) - Tuesdays 13:00 to 14:00 CET
+- 📅 [Architecture Board](https://raw.githubusercontent.com/eclipse-opensovd/opensovd/refs/heads/main/meetings/Eclipse_OpenSOVD_-_Architecture_Board.ics) - Mondays 11:30 to 12:30 CET
+- 📅 [Workstream CDA](https://raw.githubusercontent.com/eclipse-opensovd/opensovd/refs/heads/main/meetings/Eclipse_OpenSOVD_-_Workstream_CDA.ics) - Mondays 14:00 to 15:00 CET
+- 📅 [Workstream Core](https://raw.githubusercontent.com/eclipse-opensovd/opensovd/refs/heads/main/meetings/Eclipse_OpenSOVD_-_Workstream_Core.ics) (Server, Gateway & Client) - Tuesdays 11:30 to 12:15 CET
+- 📅 [Workstream UDS2SOVD](https://raw.githubusercontent.com/eclipse-opensovd/opensovd/refs/heads/main/meetings/Eclipse_OpenSOVD_-_Workstream_UDS2SOVD.ics) - Tuesdays 13:00 to 14:00 CET
 
 More work streams and meeting series will be added as the project evolves — stay tuned and get involved!


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
Links to .ics files now point to the raw file content URLs. This should improve the workflow for users simply wanting to download the files from the online rendering of the README.

Also now using the commonly used "Core" wording for the workstream discussing server, gateway and client matters.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally

## Provider Information

Thilo Schmitt [thilo.schmitt@mercedes-benz.com](mailto:thilo.schmitt@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
