### PR TITLE
chore: fix readme meeting link and ics file

### DIFF
--- a/Eclipse_OpenSOVD_-_Weekly_Forum.ics
+++ b/Eclipse_OpenSOVD_-_Weekly_Forum.ics
@@ -28,7 +28,7 @@ BEGIN:VEVENT
 DTSTAMP:20260629T072427Z
 DTSTART;TZID=Europe/Berlin:20250721T113000
 DTEND;TZID=Europe/Berlin:20250721T123000
-SUMMARY:[sdv-wg-OpenSOVD] Architecture Board
+SUMMARY:Eclipse OpenSOVD Weekly Forum
 UID:EVENTzJccx4CkQzGeUMc9Sp6XPA@zoom.us
 DESCRIPTION:SDV WG Meeting is inviting you to a scheduled Zoom meeting.\n
  Join Zoom Meeting\nhttps://eclipse.zoom.us/j/88644376064?pwd=Q6Z8kKaQK6O

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ serves as the central exchange format for architectural discussions and key proj
 We invite all contributors and interested parties to join the meetings, share their insights, and help
 shape the future of OpenSOVD.
 
-📅 For your convenience, you can import the following meeting invitation (as `.ics` file) to your calendar: [OpenSOVD Weekly Forum](https://raw.githubusercontent.com/eclipse-opensovd/opensovd/refs/heads/main/meetings/Eclipse_OpenSOVD_-_Weekly_Forum.ics) - Mondays 11:30 to 12:30 CET
+📅 For your convenience, you can import the following meeting invitation (as `.ics` file) to your calendar: [OpenSOVD Weekly Forum](https://raw.githubusercontent.com/eclipse-opensovd/opensovd/refs/heads/main/Eclipse_OpenSOVD_-_Weekly_Forum.ics) - Mondays 11:30 to 12:30 CET


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
The link in the README to the meeting invitation `.ics` was broken. Also the `SUMMARY` field of the `.ics` was incorrect. Fix those.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [X] I have tested my changes locally
- [X] I have added or updated documentation


## Provider Information

Thilo Schmitt [thilo.schmitt@mercedes-benz.com](mailto:thilo.schmitt@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
